### PR TITLE
Split tower_database when used in pg_host (and add newline at EOF)

### DIFF
--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -11,7 +11,7 @@ ansible_become='{{ tower_manage_install_become }}'
 admin_password='{{ tower_manage_admin_password }}'
 
 # Define Remote PostgreSQL for Tower
-pg_host='{{ tower_database }}'
+pg_host='{{ tower_database.split()[0] }}'
 pg_port='{{ tower_database_port }}'
 
 pg_database='awx'


### PR DESCRIPTION
When using additional per host variables in the inventory (eg ansible_user) for tower_database they are set in pg_host too.  If we split tower_database when assigning pg_host an only use the first element of the list, we can support additional host variables without creating a new variable specifically for pg_host. 