### PR TITLE
Set admin_user in extra install_vars

### DIFF
--- a/templates/install_vars.j2
+++ b/templates/install_vars.j2
@@ -1,1 +1,2 @@
 redhat_aws_rhui_repos: {{ tower_manage_aws_rhui_repos }}
+admin_username: {{ tower_manage_admin_username }}


### PR DESCRIPTION
Include admin_username in the extra-vars passed to setup.sh in order to have the admin_username created at install time (not everyone wants to use admin as the initial admin user). 