### PR TITLE
Enhancement run once for the tower api when adding a venv 

### DIFF
--- a/tasks/tower_create_venv.yml
+++ b/tasks/tower_create_venv.yml
@@ -45,4 +45,5 @@
     headers:
       Content-Type: "application/json"
   when: created_VirtualEnv is succeeded
+  run_once: true
 ...

--- a/tasks/tower_install.yml
+++ b/tasks/tower_install.yml
@@ -12,6 +12,7 @@
     name: "{{ tower_manage_base_packages }}"
     state: present
   when: ansible_facts['distribution'] == "CentOS"
+  become: true
 
 # Same, but on RHEL RHSCL is enabled by Tower, so disable
 - name: "Install Base Packages for Tower CLI"
@@ -21,6 +22,7 @@
     disablerepo: "{{ item }}"
   loop: "{{ tower_manage_disablerepo }}"
   when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version']|int >= 7
+  become: true
 
 # Download and Extract
 - name: "[Tower] Download and Extract Tower"

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -11,7 +11,7 @@ ansible_become='{{ tower_manage_install_become }}'
 admin_password='{{ tower_manage_admin_password }}'
 
 # Define Remote PostgreSQL for Tower
-pg_host='{{ tower_database }}'
+pg_host='{{ tower_database.split()[0] }}'
 pg_port='{{ tower_database_port }}'
 
 pg_database='awx'


### PR DESCRIPTION
When adding venvs to tower, we only need to run on one host.